### PR TITLE
damo_report: add --perf_path option

### DIFF
--- a/src/damo_report_holistic.py
+++ b/src/damo_report_holistic.py
@@ -80,7 +80,7 @@ def fmt_report_short(args):
     if args.profile is None:
         args.profile = args.access_pattern + '.profile'
 
-    cmd = ['perf', 'report', '-i', args.profile, '--stdio']
+    cmd = [args.perf_path, 'report', '-i', args.profile, '--stdio']
     output_lines = subprocess.check_output(cmd).decode().split('\n')
     output_lines = output_lines[5:21]
     lines += output_lines
@@ -176,7 +176,7 @@ def fmt_report(args):
     if args.profile is None:
         args.profile = args.access_pattern + '.profile'
 
-    cmd = ['perf', 'report', '-i', args.profile, '--stdio']
+    cmd = [args.perf_path, 'report', '-i', args.profile, '--stdio']
     output = subprocess.check_output(cmd).decode()
     lines.append('\n'.join(output.split('\n')[:30]))
 
@@ -203,4 +203,6 @@ def set_argparser(parser):
             '--profile', metavar='<file>', help='profile record file')
     parser.add_argument(
             '--long', action='store_true', help='make long report')
+    parser.add_argument('--perf_path', type=str, default='perf',
+                        help='path of perf tool')
     parser.description = 'Show a holistic access pattern report'

--- a/src/damo_report_profile.py
+++ b/src/damo_report_profile.py
@@ -37,7 +37,7 @@ def main(args):
         print('No snapshot of the condition found')
         exit(1)
 
-    cmd = ['perf', 'report', '-i', args.inputs[1]]
+    cmd = [args.perf_path, 'report', '-i', args.inputs[1]]
     for interval in times:
         cmd += ['--time', ','.join(['%s' % (t / 1000000000) for t in interval])]
     subprocess.call(cmd)
@@ -46,6 +46,8 @@ def set_argparser(parser):
     parser.add_argument('--inputs', metavar='<file>', nargs=2,
                         default=['damon.data', 'damon.data.profile'],
                         help='access pattern and profile record files')
+    parser.add_argument('--perf_path', type=str, default='perf',
+                        help='path of perf tool')
     _damo_records.set_filter_argparser(parser)
 
     parser.description='Show profiling report for specific access pattern'


### PR DESCRIPTION
Add --perf_path option to 'damo report holistic' and 'damo report profile'. This option is used to specify the path to the perf tool.