### PR TITLE
sort with node_id and start when collapse_ranges for memblock

### DIFF
--- a/src/damo_pa_layout.py
+++ b/src/damo_pa_layout.py
@@ -45,7 +45,7 @@ def readfile(file_path):
         return f.read()
 
 def collapse_ranges(ranges):
-    ranges = sorted(ranges, key=lambda x: x.start)
+    ranges = sorted(ranges, key=lambda x: (x.nid, x.start))
     merged = []
     for r in ranges:
         if not merged:


### PR DESCRIPTION
if sort by start only, memblock would be 
memblocks:
0-80000000, nid 0, state online, name None
100000000-3380000000, nid 0, state online, name None
3380000000-3400000000, nid 2, state online, name None
3380000000-3400000000, nid 0, state online, name None
3400000000-8080000000, nid 2, state online, name None
35e80000000-39180000000, nid 1, state online, name None
39180000000-39200000000, nid 3, state online, name None
39180000000-39200000000, nid 1, state online, name None
39200000000-3de80000000, nid 3, state online, name None
3de80000000-3ee80000000, nid 2, state online, name None
and might caculate out ranges:
paddr_region_of
35e80000000 - 39200000000
39180000000 - 39200000000
so need to change to  sort with nid and start