### PR TITLE
Weighted Interleave Updates

### DIFF
--- a/scripts/weighted_interleave.sh
+++ b/scripts/weighted_interleave.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+
+# This script shows example usage of damo for access-aware weighted
+# interleaving. The script assumes the system has two NUMA nodes of id 0 and 1.
+# The script asks DAMON to interleave hot pages of the target process, passed
+# as the first command line argument of this script, at a 1:1 ratio between
+# nodes 0 and 1. 
+#
+# To run this, the kernel should have the weighted interleaving support of
+# DAMON[1], which is expected to land into mainline in v6.17-rc1.
+#
+# [1] https://lore.kernel.org/r/20250709005952.17776-1-bijan311@gmail.com/
+
+set -e
+
+bindir=$(realpath $(dirname "$0"))
+damo_bin="$bindir/../damo"
+target_proc=$1
+
+if [ ! -f "$damo_bin" ]
+then
+	echo "damo not found at $damo_bin"
+	exit 1
+fi
+
+"$damo_bin" start \
+	--target_pid $target_proc --ops vaddr \
+		--monitoring_intervals_goal 4% 3 5ms 10s \
+		--damos_action migrate_hot 0 1 1 1 --damos_access_rate 5% max \
+		--damos_apply_interval 1s \
+		--damos_quota_interval 1s --damos_quota_space 200MB \

--- a/src/_damo_records.py
+++ b/src/_damo_records.py
@@ -978,7 +978,7 @@ def add_childs_target(kdamonds):
 
         # commit the new set of targets
         kdamonds[0].contexts[0].targets = new_targets
-        err = _damon.commit(kdamonds)
+        err = _damon.commit(kdamonds, commit_targets_only=True)
         if err is not None:
             return 'commit failed (%s)' % err
     return None

--- a/src/_damon.py
+++ b/src/_damon.py
@@ -1515,6 +1515,11 @@ def damon_interface():
 def stage_kdamonds(kdamonds):
     return _damon_fs.stage_kdamonds(kdamonds)
 
+def stage_kdamonds_targets(kdamonds):
+    if _damon_fs == _damon_dbgfs:
+        return 'debugfs interface does not support stage_kdamonds_target'
+    return _damon_fs.stage_kdamonds_targets(kdamonds)
+
 def commit_staged(kdamond_idxs):
     if _damon_fs == _damon_dbgfs:
         return 'debugfs interface does not support commit_staged()'
@@ -1525,11 +1530,15 @@ def commit_quota_goals(kdamond_idxs):
         return 'debugfs interface does not support commit_quota_goals()'
     return _damon_fs.commit_quota_goals(kdamond_idxs)
 
-def commit(kdamonds, commit_quota_goals_only=False):
-    if not commit_quota_goals_only:
+def commit(kdamonds, commit_quota_goals_only=False, commit_targets_only=False):
+    if not commit_quota_goals_only and not commit_targets_only:
         err = stage_kdamonds(kdamonds)
         if err:
             return 'staging updates failed (%s)' % err
+    elif commit_targets_only:
+        err = stage_kdamonds_targets(kdamonds)
+        if err:
+            return 'staging target updates failed (%s)' % err
 
     kdamond_idxs = ['%s' % idx for idx, k in enumerate(kdamonds)]
 

--- a/src/_damon_sysfs.py
+++ b/src/_damon_sysfs.py
@@ -614,6 +614,29 @@ def stage_kdamonds(kdamonds):
     # Assume caller checked supported()
     return write_kdamonds_dir(get_kdamonds_dir(), kdamonds)
 
+def stage_kdamonds_targets(kdamonds):
+    kdamonds_dir_path = get_kdamonds_dir()
+
+    err = ensure_nr_file_for(os.path.join(kdamonds_dir_path, 'nr_kdamonds'), kdamonds)
+    if err:
+        return err
+
+    for k_idx, kdamond in enumerate(kdamonds):
+        contexts_dir_path = os.path.join(kdamonds_dir_path, '%d' % k_idx, 'contexts')
+        contexts = kdamond.contexts
+
+        err = ensure_nr_file_for(os.path.join(contexts_dir_path, 'nr_contexts'), contexts)
+        if err:
+            return err
+
+        for c_idx, context in enumerate(contexts):
+            targets_dir_path = os.path.join(contexts_dir_path, '%d' % c_idx, 'targets')
+            err = write_targets_dir(targets_dir_path, context.targets)
+            if err:
+                return err
+
+    return None
+
 # for current_kdamonds()
 
 def numbered_dirs_content(files_content, nr_filename):


### PR DESCRIPTION
Hi SJ,

This PR adds a couple of additions to damo.

The first patch is a minor change to how _damo_records.add_childs_target works. Previously, when a new target was added, it would completely rewrite all of the sysfs files with its cached copy in the kdamonds data structure. This would be problematic for me because when updating the interleave weights, I found it easiest to manually update the weights sysfs files and commit. I also would start damo with the --include_child_tasks flag. This meant that whenever a new target was added, damo would overwrite the weights I had changed. My patch changes _damo_records.add_childs_target to only write the sysfs files relevant to updated the DAMON targets.
I am not very familiar with the damo source, so I implemented this the easiest way I could. However, if you have a better way to implement this, please let me know.

The second patch adds a simple example script showing how to use weighted targets in the migrate_{hot,cold} actions.

Thanks,
Bijan