### PR TITLE
_damo_records.add_childs_target: Revert to old target list on failure

### DIFF
--- a/src/_damo_records.py
+++ b/src/_damo_records.py
@@ -980,6 +980,7 @@ def add_childs_target(kdamonds):
         kdamonds[0].contexts[0].targets = new_targets
         err = _damon.commit(kdamonds, commit_targets_only=True)
         if err is not None:
+            kdamonds[0].contexts[0].targets = current_targets
             return 'commit failed (%s)' % err
     return None
 


### PR DESCRIPTION
_damo_records.add_childs_target goes through the list of targets, checks if they have children, and adds those children to a list of new targets. Those new targets get added to the kdamonds data structure's list of targets, and then the targets are committed to DAMON. However, if the commit fails, the new targets will be placed in kdamonds' data structure, even though they are not tracked by DAMON. This prevents those new processes from being tracked by DAMON until another child task is created.

To avoid this problem, this patch reverts kdamonds' target list to the original on failure.