### PR TITLE
release_note: add missing 3.0.8 section

### DIFF
--- a/release_note
+++ b/release_note
@@ -1,11 +1,13 @@
 This file records important changes that made in each release.  Those are
 picked by human sense, so could be incomplete and missing many things.
 
+v3.0.8
+- Add --sample_primitives option.
+
 v3.0.7
 - sysinfo: Support perf information.
 - sysinfo: Support <5.15 DAMON version inference.
 - Support 'damon sample control' feature.
-- Add --sample_primitives option.
 
 v3.0.6
 - damo report damon: Support yaml format with --format option.


### PR DESCRIPTION
Looks like in https://github.com/damonitor/damo/commit/93eaad7484d11ddc11766bf4b5b5bedcf9dc74a6

the change meant for 3.0.8 got appended to the 3.0.7 section instead