### PR TITLE
damo_args_damon: Pass the args format as positional parameter

### DIFF
--- a/src/damo_args_damon.py
+++ b/src/damo_args_damon.py
@@ -56,7 +56,7 @@ def main(args):
             print('--out and report format cannot be used together')
             exit(1)
         damo_report_damon.pr_kdamonds(
-                kdamonds, json_format=False, raw_nr=args.raw, show_cpu=False)
+                kdamonds, args.format, raw_nr=args.raw, show_cpu=False)
         return
 
     if args.format == 'json':

--- a/src/damo_version.py
+++ b/src/damo_version.py
@@ -26,8 +26,11 @@ def get_real_version():
         return get_release_version()
     if not avail_cmd('git'):
         return get_release_version()
-    return subprocess.check_output(
-            ['git', '--git-dir', git_dir, 'describe']).decode().strip()
+    try:
+        return subprocess.check_output(
+                ['git', '--git-dir', git_dir, 'describe']).decode().strip()
+    except subprocess.CalledProcessError:
+        return get_release_version()
 
 def main(args):
     print(get_release_version())


### PR DESCRIPTION
The json_format argument of pr_kdamonds was renamed and changed it's type to a positional argument in 0b08aac30e9d ("damo_report_damon: add --format option"). The input args.format values range is the same as pr_kdamonds handles so pass it directly.

## Testing
Found this problem while trying the arguments printing from the user guide [1]. Tested on Ubuntu 24.04:
```
user@vm-dev:~/damo$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.3 LTS
Release:        24.04
Codename:       noble
```

Before:
```
user@vm-dev:~/damo$ sudo ./damo args damon --format report \
  --ops paddr --regions 100-200 --damos_action migrate_cold 1 \
  --ops paddr --regions 400-700 --damos_action migrate_hot 0 \
  --nr_targets 1 1 --nr_schemes 1 1 --nr_ctxs 1 1
Traceback (most recent call last):
  File "/home/user/damo/./damo", line 135, in <module>
    main()
  File "/home/user/damo/./damo", line 132, in main
    subcmd.execute(args)
  File "/home/user/damo/src/_damo_subcmds.py", line 29, in execute
    self.module.main(args)
  File "/home/user/damo/src/damo_args.py", line 22, in main
    subcmd.execute(args)
  File "/home/user/damo/src/_damo_subcmds.py", line 29, in execute
    self.module.main(args)
  File "/home/user/damo/src/damo_args_damon.py", line 58, in main
    damo_report_damon.pr_kdamonds(
TypeError: pr_kdamonds() got an unexpected keyword argument 'json_format'
```

After:
```
user@vm-dev:~/damo$ sudo ./damo args damon --format report   --ops paddr --regions 100-200 --damos_action migrate_cold 1   --ops paddr --regions 400-700 --damos_action migrate_hot 0   --nr_targets 1 1 --nr_schemes 1 1 --nr_ctxs 1 1
kdamond 0
    context 0
        ops: paddr
        target 0
            region [100, 200) (100 B)
        intervals: sample 5 ms, aggr 100 ms, update 1 s
        nr_regions: [10, 1,000]
        scheme 0
            action: migrate_cold to node 1 per aggr interval
            target access pattern
                sz: [0 B, max]
                nr_accesses: [0 %, 18,446,744,073,709,551,615 %]
                age: [0 ns, max]
            quotas
                0 ns / 0 B / 0 B per max
                priority: sz 0 %, nr_accesses 0 %, age 0 %
            watermarks
                metric none, interval 0 ns
                0 %, 0 %, 0 %
        access sample control
        enabled primitives: page_table
kdamond 1
    context 0
        ops: paddr
        target 0
            region [400, 700) (300 B)
        intervals: sample 5 ms, aggr 100 ms, update 1 s
        nr_regions: [10, 1,000]
        scheme 0
            action: migrate_hot to node 0 per aggr interval
            target access pattern
                sz: [0 B, max]
                nr_accesses: [0 %, 18,446,744,073,709,551,615 %]
                age: [0 ns, max]
            quotas
                0 ns / 0 B / 0 B per max
                priority: sz 0 %, nr_accesses 0 %, age 0 %
            watermarks
                metric none, interval 0 ns
                0 %, 0 %, 0 %
        access sample control
        enabled primitives: page_table
```

[1] https://github.com/damonitor/damo/blob/next/USAGE.md