### PR TITLE
  tests: fix schemes-filters cleanup and prcl sub-test

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,6 +3,8 @@
 
 bindir=$(dirname "$0")
 cd "$bindir" || exit 1
+# Stop any stale DAMON from previous tests
+sudo ../../damo stop 2>/dev/null
 
 restart_damon_stat="false"
 damon_stat_enabled_file="/sys/module/damon_stat/parameters/enabled"

--- a/tests/schemes/test.sh
+++ b/tests/schemes/test.sh
@@ -249,9 +249,9 @@ test_filters() {
 	fi
 
 	prcl_damos_json="prcl_damos.json"
-	sudo "$damo" start -c "$prcl_damos_json" 2> /dev/null
 	"./$workload" &
 	workload_pid=$!
+	sudo "$damo" start "$workload_pid" -c "$prcl_damos_json" 2> /dev/null
 	sleep 5
 	rss=$(ps -o rss=, --pid "$workload_pid")
 	if [ "$rss" -gt 500000 ]

--- a/tests/schemes/test.sh
+++ b/tests/schemes/test.sh
@@ -257,7 +257,7 @@ test_filters() {
 	if [ "$rss" -gt 500000 ]
 	then
 		echo "FAIL $testname (prcl doesn't work: $rss)"
-		exit 1
+		kill -9 "$workload_pid" 2> /dev/null; sudo "$damo" stop 2> /dev/null; return 1
 	fi
 	kill -9 "$workload_pid"
 	sudo "$damo" stop 2> /dev/null
@@ -271,7 +271,7 @@ test_filters() {
 	if [ "$rss" -lt 800000 ]
 	then
 		echo "FAIL $testname (prcl_no_anon doesn't work: $rss)"
-		exit 1
+		kill -9 "$workload_pid" 2> /dev/null; sudo "$damo" stop 2> /dev/null; return 1
 	fi
 	kill -9 "$workload_pid"
 	sudo "$damo" stop 2> /dev/null
@@ -304,7 +304,7 @@ test_filters() {
 	if [ "$rss" -lt 800000 ]
 	then
 		echo "FAIL $testname (prcl_no_cgroup doesn't work: $rss)"
-		exit 1
+		kill -9 "$workload_pid" 2> /dev/null; sudo "$damo" stop 2> /dev/null; return 1
 	fi
 	kill -9 "$workload_pid"
 	sudo "$damo" stop 2> /dev/null
@@ -355,7 +355,7 @@ do
 	       2> /dev/null | \
 		grep -w "schemes_filters" > /dev/null
 	then
-		test_filters
+		test_filters || exit 1
 	fi
 done
 


### PR DESCRIPTION
Fix two issues in the schemes-filters test that caused cascade failures
  when running `./tests/run.sh`.

  ### Problem 1: stale DAMON on test failure

  `test_filters()` starts DAMON via `damo start` and then checks the
  workload RSS.  If the check failed, it called `exit 1` without
  stopping DAMON or killing the workload.  The next test then failed:

      FAIL record-validate "sleep 5" 5 none sysfs
      (damo-record command failed with value 254)
      could not turn DAMON on (writing on to .../state failed
      ([Errno 16] Device or resource busy))

  Fix: stop DAMON and kill the workload before returning on all three
  failure paths, and propagate the return value to the caller.  Also
  add a defensive DAMON stop at the start of run.sh.

  ### Problem 2: prcl sub-test uses paddr by default

  The prcl sub-test used `damo start -c prcl_damos.json` without a
  target, defaulting to paddr monitoring.  The scheme targets the 0th
  percentile (nr_accesses == 0).  After the arm64 kernel TLB fix [1],
  access detection works correctly and pages with non-zero access
  counts no longer match, so the workload pages are never reclaimed:

      FAIL schemes-filters sysfs (prcl doesn't work: 1049324)

  Fix: start the workload first, then target it with its PID, which
  switches to vaddr monitoring and tests pageout directly.

  [1] https://lore.kernel.org/damon/20260520113934.xxx/

  ## Tested on

  - arm64 (Phytium, 128 cores, 7.0.0-next-20260424+)
  - `./tests/run.sh` passes all tests
  - `./damon-tests/corr/run.sh` passes all tests

 Co-developed-by: Wang Lian <lianux.mm@gmail.com>
 Signed-off-by: Kunwu Chan <kunwu.chan@gmail.com>
