### PR TITLE
_damo_sysinfo: handle unusable perf in get_perf_path_version()

### DIFF
--- a/src/_damo_sysinfo.py
+++ b/src/_damo_sysinfo.py
@@ -242,10 +242,10 @@ def get_perf_path_version():
         perf_path = subprocess.check_output(['which', 'perf']).decode().strip()
     except:
         perf_path = None
-    if perf_path is not None:
+    try:
         perf_version = subprocess.check_output(
                 ['perf', '--version']).decode().strip()
-    else:
+    except:
         perf_version = None
     return perf_path, perf_version
 


### PR DESCRIPTION
get_perf_path_version() guards the 'which perf' lookup but then runs 'perf --version' via subprocess.check_output() without a guard.  On systems where perf is installed but unusable (e.g. a kernel without a matching linux-tools package, where /usr/bin/perf is a wrapper that exits non-zero), check_output() raises CalledProcessError.  This propagates out of get_sysinfo() during initialization and crashes damo before any record backend is selected, even when trace-cmd is available.

Wrap the 'perf --version' call so a failure sets perf_version to None, mirroring how get_trace_cmd_version() already tolerates a missing or broken trace-cmd.

Found and verified on a kernel with no matching linux-tools (perf
present but exiting non-zero): after this change, damo init no longer
crashes and proceeds to trace-cmd.

Signed-off-by: Sean Jackson <sjackson@crusoe.ai>