### PR TITLE
_damo_records: locate timestamp field instead of assuming column index

### DIFF
--- a/src/_damo_records.py
+++ b/src/_damo_records.py
@@ -484,7 +484,21 @@ def damon_trace_fields(line):
     fields = line.split()
     if len(fields) < 4:
         return None
-    return fields[3:]
+    # The number of leading columns before the timestamp varies: some
+    # 'trace-cmd report' / 'perf script' outputs include a flags column (e.g.
+    # '.....') while others omit it.  Rather than assuming a fixed index, find
+    # the timestamp field and return from there.  The timestamp is the field
+    # that ends with ':' and parses as a float (e.g. '92627.258073:'); the
+    # event name ('damon_aggregated:') and region ('...-...:') also end with
+    # ':' but are not floats, so they are skipped.
+    for idx, field in enumerate(fields):
+        if field.endswith(':'):
+            try:
+                float(field[:-1])
+            except ValueError:
+                continue
+            return fields[idx:]
+    return None
 
 def parse_damon_trace(trace_text, monitoring_intervals):
     '''
@@ -1216,6 +1230,7 @@ def start_damon_tracing(handle):
                     ['trace-cmd', 'record', '-o', handle.file_path] +
                     tracepoints_option,
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
     if handle.do_profile:
         cmd = [perf_cmd, 'record', '-o', '%s.profile' % handle.file_path]
         handle.perf_profile_pipe = subprocess.Popen(cmd)

--- a/tests/unit/test_damo_records.py
+++ b/tests/unit/test_damo_records.py
@@ -151,6 +151,15 @@ class TestDamon(unittest.TestCase):
             ['92566.021974:', 'damon_aggregated:', 'target_id=0',
              'nr_regions=11', '4294967296-4701806592:', '0'])
 
+        # trace-cmd report output without the flags column (some trace-cmd
+        # versions omit it, so the timestamp is one field earlier)
+        self.assertEqual(_damo_records.damon_trace_fields(
+            '       kdamond.0-12015 [096]  5653.356782: '
+            'damon_aggregated:     target_id=0 nr_regions=52 '
+            '4194304-108617728: 0 10'),
+            ['5653.356782:', 'damon_aggregated:', 'target_id=0',
+             'nr_regions=52', '4194304-108617728:', '0', '10'])
+
         # perf script output
         self.assertEqual(
                 _damo_records.damon_trace_fields(


### PR DESCRIPTION
damon_trace_fields() returned fields[3:], assuming the timestamp is always the 4th whitespace-separated field of 'trace-cmd report' / 'perf script' output.  That holds only when a flags column (e.g. '.....') is present.  Some trace-cmd versions omit it, shifting every field left by one, so fields[3:] starts at the event name; parse_damon_trace_region() then reads the wrong field as the tracepoint name and no records are parsed, producing an empty recording with no error.

Find the timestamp field (the ':'-terminated field that parses as a float) and return from there, making parsing independent of the number of leading columns.

Adds a unit test covering the no-flags-column line (verified to fail
before this change and pass after). Found while recording DAMON access
patterns via trace-cmd on a kernel where 'trace-cmd report' omits the
flags column.

Signed-off-by: Sean Jackson <sjackson@crusoe.ai>