### PR TITLE
damo_report_heatmap: fix age backfill causing inflated access frequency in full recordings

### DIFF
--- a/src/damo_report_heatmap.py
+++ b/src/damo_report_heatmap.py
@@ -85,12 +85,14 @@ class HeatMap:
         return int((addr - self.addr_start) / self.addr_unit)
 
     def add_pixel_heat(self, pixels_idx, pixel_idx, region, snapshot,
-                       record_intervals, df_passed):
+                       last_snapshot, record_intervals, df_passed):
         pixel = self.pixels[pixels_idx][pixel_idx]
         observe_start_time = snapshot.start_time
         if record_intervals is not None:
             observe_start_time -= region.age.aggr_intervals * \
                     record_intervals.aggr * 1000
+            if last_snapshot is not None and observe_start_time < last_snapshot.end_time:
+                observe_start_time = last_snapshot.end_time
 
         account_time_start = max(observe_start_time, pixel.time)
         account_time_end = min(snapshot.end_time, pixel.time + self.time_unit)
@@ -150,7 +152,7 @@ class HeatMap:
                         continue
                     self.add_pixel_heat(
                             pixels_idx, pixel_idx, region, snapshot,
-                            record_intervals, df_passed)
+                            last_snapshot, record_intervals, df_passed)
 
     def highest_lowest_heats(self):
         highest = None


### PR DESCRIPTION
When damo record captures a full continuous recording (one snapshot per aggregation interval), damo report heatmap inflates access frequencies by 2-3x due to double-counting in add_pixel_heat().

Root cause:

add_pixel_heat() extends observe_start_time backwards using region age:
  observe_start_time -= region.age.aggr_intervals * record_intervals.aggr * 1000

This is useful for sparse recordings (e.g. damo show with a single snapshot) where age tells you how long the region has been in that state, filling in history that was not recorded.

However, pixels_idxs_range() already clips this extended range against the previous snapshot:
  if last_snapshot is not None and start_time < last_snapshot.end_time:
      start_time = last_snapshot.end_time

add_pixel_heat() does NOT apply the same clip when computing account_time. In a continuous recording every snapshot extends its observe window into the previous snapshot already-accounted time, causing the same period to be counted multiple times.

Effect:

With a 200 Hz hammer process (5ms sampling / 100ms aggregation), the heatmap reported 500-1400 Hz. The inflation factor is (age_cycle_length + 1) / 2.

Fix:

Apply the same last_snapshot clip in add_pixel_heat() that pixels_idxs_range() already uses. Pass last_snapshot through add_heat() into add_pixel_heat().

Verification:

After the fix, damo report heatmap correctly reports 136-196 Hz for a 200 Hz target process (within the theoretical max of 200 Hz = 1/sample_interval).
