### PR TITLE
damo_module_stat: fix no output for stat read without arguments

### DIFF
--- a/src/damo_module_stat.py
+++ b/src/damo_module_stat.py
@@ -182,8 +182,11 @@ def handle_read_write(args):
                 exit(1)
         else:
             input_idle_time_percentiles = None
-        for to_read in args.to_read:
-            handle_read(to_read, args, input_idle_time_percentiles, param_dir)
+        if args.to_read:
+            for to_read in args.to_read:
+                handle_read(to_read, args, input_idle_time_percentiles, param_dir)
+        else:
+            handle_read(None, args, input_idle_time_percentiles, param_dir)
     elif args.action == 'write':
         if len(args.parameter_value) % 2 != 0:
             print('wrong paramter_value')


### PR DESCRIPTION
When 'damo module stat read' is invoked without arguments, it exits silently with no output.

This happens because handle_read_write() iterates over args.to_read. Since the list is empty when no arguments are given, handle_read() is never called and the "list all parameters" fallback (to_read is None) is never reached.

Fix this by explicitly calling handle_read(to_read=None) when args.to_read is empty to dump all parameters.